### PR TITLE
Add grunt option to supress yuidocjs warnings

### DIFF
--- a/tasks/concat_deps.js
+++ b/tasks/concat_deps.js
@@ -20,14 +20,13 @@ module.exports = function(grunt) {
 	 * @returns {{modules: string[], requires: string[]}[]}
 	 * @private
 	 */
-	var parseModules = function(filename, code) {
+	var parseModules = function(filename, code, options) {
 		var parser = new (yuidoc.DocParser)({
 			syntaxtype: 'js'
 		});
 
-		var options = {};
-		options[filename] = code;
-		parser.parse(options);
+		yuidoc.config.debug = options.debug == undefined ? true : options.debug;
+		parser.parse({ filename: code });
 
 		var modules = [];
 		var requires = [];
@@ -126,7 +125,7 @@ module.exports = function(grunt) {
 					return;
 				}
 				grunt.verbose.writeln('Parsing ' + srcFile);
-				modules.push(parseModules(srcFile, grunt.file.read(srcFile)));
+				modules.push(parseModules(srcFile, grunt.file.read(srcFile), options));
 			});
 			grunt.verbose.writeln('Resolving dependencies for ' + modules.length +
 			                      ' files');


### PR DESCRIPTION
Allow users to pass debug:true|false as a grunt build option
to supress the "warn: (DocParser)" error messages if desired

Not sure why github shows the whole file contents as being added/deleted, I only changed one line:

yuidoc.config.debug = options.debug == undefined ? true : options.debug;

Added to the parseModules function.
