### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,56 +1,56 @@
 {
-	"name":             "grunt-concat-deps",
-	"description":      "Grunt plugin for concatenating files according to their declarative module definitions.",
-	"version":          "0.2.1",
-	"homepage":         "https://github.com/leoselig/grunt-concat-deps",
-	"author":           "Leo Selig <selig.git@gmail.com>",
-	"repository":       {
+	"name": "grunt-concat-deps",
+	"description": "Grunt plugin for concatenating files according to their declarative module definitions.",
+	"version": "0.2.1",
+	"homepage": "https://github.com/leoselig/grunt-concat-deps",
+	"author": "Leo Selig <selig.git@gmail.com>",
+	"repository": {
 		"type": "git",
-		"url":  "https://github.com/leoselig/grunt-concat-deps.git"
+		"url": "https://github.com/leoselig/grunt-concat-deps.git"
 	},
-	"bugs":             {
+	"bugs": {
 		"url": "https://github.com/leoselig/grunt-concat-deps/issues"
 	},
-	"licenses":         [
+	"licenses": [
 		{
 			"type": "MIT",
-			"url":  "https://github.com/leoselig/grunt-concat-deps/blob/master/LICENSE-MIT"
+			"url": "https://github.com/leoselig/grunt-concat-deps/blob/master/LICENSE-MIT"
 		}
 	],
-	"main":             "Gruntfile.js",
-	"engines":          {
+	"main": "Gruntfile.js",
+	"engines": {
 		"node": ">= 0.8.0"
 	},
-	"scripts":          {
+	"scripts": {
 		"test": "grunt test"
 	},
-	"devDependencies":  {
-		"grunt-contrib-jshint":   "~0.6.0",
-		"grunt-contrib-clean":    "~0.4.0",
+	"devDependencies": {
+		"grunt-contrib-jshint": "~0.6.0",
+		"grunt-contrib-clean": "~0.4.0",
 		"grunt-contrib-nodeunit": "~0.2.0",
-		"grunt":                  "~0.4.1",
-		"yuidocjs":               "~0.3.45",
-		"underscore":             "~1.5.2"
+		"grunt": "~0.4.1",
+		"yuidocjs": "~0.3.45",
+		"underscore": "~1.5.2"
 	},
 	"peerDependencies": {
-		"grunt": "~0.4.1"
+		"grunt": ">=0.4.0"
 	},
-	"keywords":         [
+	"keywords": [
 		"gruntplugin"
 	],
-	"readmeFilename":   "README.md",
-	"gitHead":          "cfd880fff3ef0448bb0e8b08fed1d4e16d377f93",
-	"directories":      {
+	"readmeFilename": "README.md",
+	"gitHead": "cfd880fff3ef0448bb0e8b08fed1d4e16d377f93",
+	"directories": {
 		"test": "test"
 	},
-	"dependencies":     {
-		"grunt-contrib-clean":    "~0.4.1",
-		"grunt":                  "~0.4.1",
-		"esprima":                "~1.0.4",
-		"yuidocjs":               "~0.3.45",
-		"underscore":             "~1.5.2",
+	"dependencies": {
+		"grunt-contrib-clean": "~0.4.1",
+		"grunt": "~0.4.1",
+		"esprima": "~1.0.4",
+		"yuidocjs": "~0.3.45",
+		"underscore": "~1.5.2",
 		"grunt-contrib-nodeunit": "~0.2.1",
-		"grunt-contrib-jshint":   "~0.6.4"
+		"grunt-contrib-jshint": "~0.6.4"
 	},
-	"license":          "MIT"
+	"license": "MIT"
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
